### PR TITLE
Separate recheck intervals for away and present

### DIFF
--- a/unifi/unifi-child-presence.groovy
+++ b/unifi/unifi-child-presence.groovy
@@ -18,7 +18,8 @@ metadata {
     preferences {
         section("Device Settings:") {
             input "mac_addr", "string", title:"Mac Address of Client to Track", description: "", required: true, displayDuringSetup: true, defaultValue: ""
-            input "timedelay", "number", title:"Number of seconds before rechecking", description: "", required: true, displayDuringSetup: true, defaultValue: "600"
+            input "timedelay", "number", title:"Number of seconds before rechecking when present", description: "", required: true, displayDuringSetup: true, defaultValue: "600"
+            input "timedelayAway", "number", title:"Number of seconds before rechecking when away", description: "", required: true, displayDuringSetup: true, defaultValue: "600"
             input name: "logEnable", type: "bool", title: "Enable debug logging", defaultValue: false
             input name: "autoUpdate", type: "bool", title: "Enable Auto updating", defaultValue: true
         }
@@ -97,12 +98,12 @@ void Update(){
     if (status3) {
         if (logEnable) log.info "present  ${device.getName()}  ${mac_addr}"
         sendEvent(name: "presence", value: "present")
+        if (autoUpdate) runIn(timedelay.toInteger(), Update)
+
     } else {
         if (logEnable) log.info "not present  ${device.getName()}  ${mac_addr}"
         sendEvent(name: "presence", value: "not present")
+       if (autoUpdate) runIn(timedelayAway.toInteger(), Update)
     }
     
-    if (autoUpdate) runIn(timedelay.toInteger(), Update)
 }
-
-


### PR DESCRIPTION
A simple improvement that allows configuring different re-check intervals for "present" and "not present" modes.
For example, I generally don't care how long does it take to detect that I left the house; but I want the hub to detect my arrival as soon as possible; so I set timedelay to 300 seconds and timedelayAway to 10. 