### PR TITLE
ignore controller errors

### DIFF
--- a/unifi/unifi-child-presence-wired.groovy
+++ b/unifi/unifi-child-presence-wired.groovy
@@ -57,6 +57,9 @@ void Update(){
     if (logEnable) log.info status2
     
     if(status2.equals("") || status2 == null) {
+        if (autoUpdate) runIn(timedelayAway.toInteger(), Update)
+        return
+    } else if (status2.equals("not_present")) {
         status3 = false
     } else {
         status3 = true

--- a/unifi/unifi-child-presence.groovy
+++ b/unifi/unifi-child-presence.groovy
@@ -58,6 +58,9 @@ void Update(){
     status2 = parent.ChildGetClientConnected(mac_addr)
     
     if(status2.equals("") || status2 == null ) {
+        if (autoUpdate) runIn(timedelayAway.toInteger(), Update)
+        return
+    } else if (status2.equals("not_present")) {
         status3 = false
     } else {
         status3 = true

--- a/unifi/unifi-parent.groovy
+++ b/unifi/unifi-parent.groovy
@@ -330,6 +330,10 @@ def GetClientConnected(String mac) {
     } catch (Exception e){
         if (logEnable) log.info e     
         if(e.toString().contains( "groovyx.net.http.HttpResponseException:") )  {
+            if (e.response.status == 400 && e.response.data && e.response.data.meta && e.response.data.meta.rc == "error" && e.response.data.meta.msg.contains("UnknownStation")) {
+                // this is a definitive response from the UniFi controller that such client is currently not connected
+                return "not_present"
+            }
             if (logEnable) log.info "check login"
             Login()
         }


### PR DESCRIPTION
 i.e. stop treating connectivity issues to the UniFi controller as an immediate 'not present'. 
Helps prevent unnecessary "everyone left" events when controller is being upgraded/rebooted or just not available, especially on networks with standalone controllers, separate from the gateway.